### PR TITLE
add `flatMap` alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,17 @@ Current [Stage](https://tc39.es/process-document/): 0
 
 ## Motivation
 
-Using Array methods to compute new values while rejecting certain entries can currently be solved in 3 predominant ways:
+Using Array methods to compute new values while rejecting certain entries can currently be solved in 4 predominant ways:
 
 - Use `.filter` and `.map`, invoking two iterations over the array and allocating two sets of arrays.
+- Use `.flatMap` with a ternary inside.
 - Use a for loop, creating an empty array and pushing into it conditionally for each iteration of the for loop.
 - Use some kind of reducer function, which can have a variety of different styles.
 
 ```js
 const names = accounts.filter((a) => a.role === "admin").map((a) => a.name)
+
+const names = accounts.flatMap((a) => a.role === "admin" ? [a.name] : [])
 
 const names = []
 for (const a of accounts) {
@@ -58,7 +61,8 @@ const names = accounts.reduce((names, a) => {
 
 These all feel like they come with some kind of compromise. The filter+map is probably the most readable, but comes at
 the cost of lowest performance among all three. `filterMap()` would solve the performance implications while also
-(arguably) improve readability.
+(arguably) improving readability. `.flatMap()` has been [suggested](https://github.com/tc39/proposal-array-filtering/issues/12#issuecomment-592192544)
+as a reason why `.filterMap()` is not needed, but it is debatable which one is more readable.
 
 ## Other languages
 


### PR DESCRIPTION
Whether this is good enough so that we don't need `filterMap` is, of course, debatable, but it should definitely be mentioned as possibly the best current alternative. See also https://github.com/tc39/proposal-array-filtering/issues/12#issuecomment-592192544